### PR TITLE
fix: fetch grammars from non-reference commits

### DIFF
--- a/_automation/main.go
+++ b/_automation/main.go
@@ -421,7 +421,7 @@ func logAndExit(logger *Logger, msg string, args ...interface{}) {
 // Git
 
 func fetchLastTag(repository string) (string, string) {
-	cmd := exec.Command("git", "ls-remote", "--tags", "--refs", "--sort", "-v:refname", repository, "v*")
+	cmd := exec.Command("git", "ls-remote", "--tags", "--sort", "-v:refname", repository, "v*")
 	b, err := cmd.Output()
 	if err != nil {
 		logAndExit(defaultLogger, err.Error())
@@ -429,7 +429,10 @@ func fetchLastTag(repository string) (string, string) {
 	line := strings.SplitN(string(b), "\n", 2)[0]
 	parts := strings.Split(line, "\t")
 
-	return strings.Split(parts[1], "/")[2], parts[0]
+	tag := strings.TrimRight(strings.Split(parts[1], "/")[2], "^{}")
+	rev := strings.Split(parts[0], "^")[0]
+
+	return tag, rev
 }
 
 func fetchLastCommit(repository, branch string) string {


### PR DESCRIPTION
Reference commits are often (but not always?) only references and not real commits that can be fetched with the `githubusercontent.com` URL.

This change removes the `--refs` filter so real commits are also included, which happen to come first with the current `ls-remote` sorting so it will use the real commit. This fixes updating of a lot of grammars which are broken today.

For example, with `--refs`:
```
> git ls-remote --tags --refs --sort -v:refname https://github.com/tree-sitter/tree-sitter-javascript | head -n5
dc2b73b62f162860cc8b55f51a21833ff98867e5	refs/tags/v0.20.1
efd8cc9ee8eb919c2ca0f0eebaeb8f39557d8a8a	refs/tags/v0.19.0
82dc6525aa91eb2cbbe5fe591a737d4f03138886	refs/tags/v0.16.0
cc57665e632f7d6b55e5b7950896f1bd26e02e43	refs/tags/v0.15.2
8f135e9f6e354c5ade9f038201f968862f1fb7ef	refs/tags/v0.15.1
```

vs without `--refs`:
```
> git ls-remote --tags --sort -v:refname https://github.com/tree-sitter/tree-sitter-javascript | head -n5
f1e5a09b8d02f8209a68249c93f0ad647b228e6e	refs/tags/v0.20.1^{}
dc2b73b62f162860cc8b55f51a21833ff98867e5	refs/tags/v0.20.1
efd8cc9ee8eb919c2ca0f0eebaeb8f39557d8a8a	refs/tags/v0.19.0
92a561dfa76cb5a4aafba16f819c3c9e1227ce83	refs/tags/v0.16.0^{}
82dc6525aa91eb2cbbe5fe591a737d4f03138886	refs/tags/v0.16.0
```

Note that `f1e5a09b8d02f8209a68249c93f0ad647b228e6e` is valid but the reference commit `dc2b73b62f162860cc8b55f51a21833ff98867e5` is not...