### PR TITLE
Save a tiny bit of memory by rearranging fields; also using the newer way to "unsafely" instantiate a slice:

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/smacker/go-tree-sitter
 
-go 1.13
+go 1.17
 
 require github.com/stretchr/testify v1.7.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)


### PR DESCRIPTION
By rearranging the fields the memory usage per type was reduced as follows:

- `Parser` 24 -> 16 bytes
- `QueryError` 24 -> 8 bytes
- `QueryCapture` 16 -> 8 bytes
- `QueryMatch` 16 -> 8 bytes
- `readFuncsMap` 16 -> 8 bytes

In practice, unless you capture the matches for the entire tree at once (AND the tree is large) there won't be any difference. However, typically you'd use `cursor.SetPointRange()` and focus on a particular area of the tree, so these savings won't be observed in practice unless somehow you are creating lots of `QueryCapture` and `QueryMatch` nodes.

Oh, and also added a TODO note, there's something in there that looks out of place and needs to be investigated further (a useless break statement).