### PR TITLE
Improve updater and Go -> 1.20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.22', '1.21', '1.20', '1.19']
+        go: ['1.23', '1.22', '1.21', '1.20']
     name: Test on ${{ matrix.go }}
     steps:
       - uses: actions/checkout@v4

--- a/_automation/main.go
+++ b/_automation/main.go
@@ -81,6 +81,7 @@ func root(args []string) error {
 		flagsParse(fs, args[1:])
 
 		s.CheckUpdates(ctx)
+
 	case "update":
 		if len(args) < 2 {
 			return fmt.Errorf("language argument is missing")
@@ -91,11 +92,15 @@ func root(args []string) error {
 		flagsParse(fs, args[2:])
 
 		s.Update(ctx, args[1], *force)
+		s.writeGrammarsFile(ctx)
+
 	case "update-all":
 		fs := flag.NewFlagSet("update-all", flag.ExitOnError)
 		flagsParse(fs, args[1:])
 
-		s.UpdateAll(ctx)
+		s.UpdateAll(ctx, true)
+		s.writeGrammarsFile(ctx)
+
 	default:
 		return fmt.Errorf("unknown sub-command")
 	}
@@ -194,33 +199,20 @@ func (s *UpdateService) Update(ctx context.Context, language string, force bool)
 	}
 
 	s.downloadGrammar(ctx, grammar)
-	s.writeGrammarsFile(ctx)
 }
 
-func (s *UpdateService) UpdateAll(ctx context.Context) {
-	newVersions := s.fetchNewVersions()
-
+func (s *UpdateService) UpdateAll(ctx context.Context, force bool) {
 	wg := sync.WaitGroup{}
-	for i, g := range s.grammars {
-		v := newVersions[i]
-		if v == nil {
-			continue
-		}
-
+	for _, g := range s.grammars {
 		wg.Add(1)
-		g.Reference = v.Reference
-		g.Revision = v.Revision
 
 		go func(g *Grammar) {
 			defer wg.Done()
 
-			s.downloadGrammar(ctx, g)
+			s.Update(ctx, g.Language, force)
 		}(g)
 	}
-
 	wg.Wait()
-
-	s.writeGrammarsFile(ctx)
 }
 
 func (s *UpdateService) downloadGrammar(ctx context.Context, g *Grammar) {
@@ -308,7 +300,7 @@ func (s *UpdateService) fetchFile(ctx context.Context, url string) []byte {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		logAndExit(logger, "incorrect response status code", "statusCode", resp.StatusCode)
+		logger.Error("incorrect response status code", "statusCode", resp.StatusCode)
 	}
 
 	b, err := io.ReadAll(resp.Body)
@@ -370,15 +362,15 @@ func (s *UpdateService) downloadPhp(ctx context.Context, g *Grammar) {
 // ocaml is special since its folder structure is different from the other ones
 func (s *UpdateService) downloadOcaml(ctx context.Context, g *Grammar) {
 	fileMapping := map[string]string{
-		"parser.c":   "ocaml/src/parser.c",
-		"scanner.cc": "ocaml/src/scanner.cc",
-		"scanner.h":  "common/scanner.h",
+		"parser.c":  "grammars/ocaml/src/parser.c",
+		"scanner.c": "grammars/ocaml/src/scanner.c",
+		"scanner.h": "include/scanner.h",
 	}
 
 	url := g.ContentURL()
 	s.downloadFile(
 		ctx,
-		fmt.Sprintf("%s/%s/ocaml/src/tree_sitter/parser.h", url, g.Revision),
+		fmt.Sprintf("%s/%s/include/tree_sitter/parser.h", url, g.Revision),
 		fmt.Sprintf("%s/parser.h", g.Language),
 		nil,
 	)

--- a/_automation/main.go
+++ b/_automation/main.go
@@ -362,15 +362,15 @@ func (s *UpdateService) downloadPhp(ctx context.Context, g *Grammar) {
 // ocaml is special since its folder structure is different from the other ones
 func (s *UpdateService) downloadOcaml(ctx context.Context, g *Grammar) {
 	fileMapping := map[string]string{
-		"parser.c":  "grammars/ocaml/src/parser.c",
-		"scanner.c": "grammars/ocaml/src/scanner.c",
-		"scanner.h": "include/scanner.h",
+		"parser.c":   "ocaml/src/parser.c",
+		"scanner.cc": "ocaml/src/scanner.cc",
+		"scanner.h":  "common/scanner.h",
 	}
 
 	url := g.ContentURL()
 	s.downloadFile(
 		ctx,
-		fmt.Sprintf("%s/%s/include/tree_sitter/parser.h", url, g.Revision),
+		fmt.Sprintf("%s/%s/ocaml/src/tree_sitter/parser.h", url, g.Revision),
 		fmt.Sprintf("%s/parser.h", g.Language),
 		nil,
 	)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/smacker/go-tree-sitter
 
-go 1.13
+go 1.23
 
-require github.com/stretchr/testify v1.7.4
+require github.com/stretchr/testify v1.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smacker/go-tree-sitter
 
-go 1.23
+go 1.20
 
 require github.com/stretchr/testify v1.9.0
 

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,10 @@
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
-github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Cleaned up the `UpdateAll` method to reuse `Update`, should be easier to maintain.


**Notes:**
_The additional indirect dependencies in `go.sum` come from `github.com/stretchr/testify` after running `go mod tidy`_